### PR TITLE
fix: set image version to 'latest'

### DIFF
--- a/deploy/production/adapter.yaml
+++ b/deploy/production/adapter.yaml
@@ -73,7 +73,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-circonus-adapter
       containers:
-      - image: circonuslabs/custom-metrics-circonus-adapter:v0.1.0
+      - image: circonuslabs/custom-metrics-circonus-adapter:latest
         imagePullPolicy: IfNotPresent
         name: pod-custom-metrics-circonus-adapter
         command:


### PR DESCRIPTION
The image version was hard coded to `v0.1.0` so no newer releases were being deployed without the user editing the deployment configuration before deploying. Using `latest` will always deploy the latest image from docker hub.