### PR TITLE
CIRC-8242: Update docker image to use latest version

### DIFF
--- a/deploy/production/adapter.yaml
+++ b/deploy/production/adapter.yaml
@@ -73,7 +73,7 @@ spec:
     spec:
       serviceAccountName: custom-metrics-circonus-adapter
       containers:
-      - image: circonuslabs/custom-metrics-circonus-adapter:latest
+      - image: circonus/custom-metrics-circonus-adapter:latest
         imagePullPolicy: IfNotPresent
         name: pod-custom-metrics-circonus-adapter
         command:


### PR DESCRIPTION
Updates the image to use `circonus/custom-metrics-circonus-adapter:latest`, which is the current image, and not `circonuslabs/custom-metrics-circonus-adapter:latest` which is old and not updated.