### PR TITLE
CIRC-9041: Fix null CAQL data value panics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 dist/
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.9
+
+* fix: Correct a bug that lead to panics when CAQL data requested contained
+null data values.
+
 # v0.1.6
 
 * fix: type assertion

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOOS?=linux
 OUT_DIR?=build
 PACKAGE=github.com/circonus-labs/custom-metrics-circonus-adapter
 PREFIX?=circonus
-TAG = v0.1.0
+TAG = v0.1.9
 PKG := $(shell find pkg/* -type f)
 
 .PHONY: build docker push test clean

--- a/pkg/adapter/provider/provider.go
+++ b/pkg/adapter/provider/provider.go
@@ -251,6 +251,9 @@ func (p *CirconusProvider) GetExternalMetric(ctx context.Context, namespace stri
 		}
 		count++
 		point := p.([]interface{})
+		if point[0] == nil {
+			continue
+		}
 		resultEndTime := point[0].(float64)
 		if resultEndTime > finalTime {
 			finalTime = resultEndTime
@@ -259,7 +262,13 @@ func (p *CirconusProvider) GetExternalMetric(ctx context.Context, namespace stri
 			return nil, apierr.NewInternalError(fmt.Errorf("timeseries from Circonus has incorrect end time: %f", resultEndTime))
 		}
 		// point_data == []interface {}
+		if point[1] == nil {
+			continue
+		}
 		pointData := point[1].([]interface{})
+		if pointData[0] == nil {
+			continue
+		}
 		value := pointData[0].(float64)
 		finalValue += value
 	}

--- a/pkg/adapter/provider/provider.go
+++ b/pkg/adapter/provider/provider.go
@@ -251,7 +251,7 @@ func (p *CirconusProvider) GetExternalMetric(ctx context.Context, namespace stri
 		}
 		count++
 		point := p.([]interface{})
-		if point[0] == nil {
+		if len(point) < 1 || point[0] == nil {
 			continue
 		}
 		resultEndTime := point[0].(float64)
@@ -262,11 +262,11 @@ func (p *CirconusProvider) GetExternalMetric(ctx context.Context, namespace stri
 			return nil, apierr.NewInternalError(fmt.Errorf("timeseries from Circonus has incorrect end time: %f", resultEndTime))
 		}
 		// point_data == []interface {}
-		if point[1] == nil {
+		if len(point) < 2 || point[1] == nil {
 			continue
 		}
 		pointData := point[1].([]interface{})
-		if pointData[0] == nil {
+		if len(pointData) < 1 || pointData[0] == nil {
 			continue
 		}
 		value := pointData[0].(float64)


### PR DESCRIPTION
* fix: Correct a bug that lead to panics when CAQL data requested contained null data values.